### PR TITLE
Add “install” step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://shiba.computer
 ```
 git clone git@github.com:shibacomputer/txt.git txt
 cd txt
+📦 npm install
 🔨 npm run rebuild
 👉 npm start
 ✨ 📝 🚀!


### PR DESCRIPTION
Dependencies are needed before you can do `npm run rebuild`, or it just fails!